### PR TITLE
OS-1252: Declare return type "void" on the handler

### DIFF
--- a/Logger/Handler/Database.php
+++ b/Logger/Handler/Database.php
@@ -24,7 +24,7 @@ class Database extends \Monolog\Handler\AbstractProcessingHandler
     /**
      * {@inheritDoc}
      */
-    protected function write(array $record)
+    protected function write(array $record): void
     {
         $model = $this->factory->create()
             ->setChannel($record['channel'])


### PR DESCRIPTION
Covariance allows a return type of a child class to be more specific
than the parent class.
See https://www.php.net/manual/en/language.oop5.variance.php